### PR TITLE
Rename "service" command to "service_instance"

### DIFF
--- a/cmd/service_instance.go
+++ b/cmd/service_instance.go
@@ -13,8 +13,8 @@ func NewServiceCommand(cliConnection cliPlugin.CliConnection) *cobra.Command {
 		"org",
 	}
 	return &cobra.Command{
-		Use:     "service",
-		Aliases: []string{"s"},
+		Use:     "service_instance",
+		Aliases: []string{"s_i"},
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			targetType := args[0]

--- a/cmd/service_instance_test.go
+++ b/cmd/service_instance_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/AP-Hunt/cf-traverse/testfixtures"
 )
 
-var _ = Describe("service", func() {
+var _ = Describe("service_instance", func() {
 	var apiServer *testfixtures.APIServer
 	var cliConnection plugin.CliConnection
 	var out bytes.Buffer


### PR DESCRIPTION
Renames "service" command to "service_instance"

A service in Cloud Foundry is also known as a service offering, and refers to a type of service. The correct term in this case is service instance.