### PR TITLE
Implements service plan to instances of relation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,21 @@ for the source entity. The table below shows all the supported source entities, 
         </tr>    
     </thead>
     <tbody>
+        <!-- Service instance -->
         <tr>
-            <td rowspan="0">service_instance</td>
-            <td rowspan="0">A service instance guid, or service instance name</td>
+            <td rowspan="5">service_instance</td>
+            <td rowspan="5">A service instance guid, or service instance name</td>
         </tr>
         <tr><td>space</td></tr>
         <tr><td>org</td></tr>
         <tr><td>plan</td></tr>
         <tr><td>service_offering</td></tr>
+        <!-- Service plan -->
+        <tr>
+            <td rowspan="2">service_plan</td>
+            <td rowspan="2">A service plan guid</td>
+        </tr>
+        <tr><td>instances_of</td></tr>
     </tbody>
 </table>
 

--- a/cmd/service_instance.go
+++ b/cmd/service_instance.go
@@ -1,13 +1,14 @@
 package cmd
 
 import (
-	cliPlugin "code.cloudfoundry.org/cli/plugin"
 	"fmt"
+
+	cliPlugin "code.cloudfoundry.org/cli/plugin"
 	cfclient "github.com/cloudfoundry-community/go-cfclient"
 	"github.com/spf13/cobra"
 )
 
-func NewServiceCommand(cliConnection cliPlugin.CliConnection) *cobra.Command {
+func NewServiceInstancesCommand(cliConnection cliPlugin.CliConnection) *cobra.Command {
 
 	return &cobra.Command{
 		Use:     "service_instance",
@@ -63,7 +64,7 @@ func NewServiceCommand(cliConnection cliPlugin.CliConnection) *cobra.Command {
 func serviceInstanceGuidFromName(client *cfclient.Client, identifier string) (string, error) {
 	listing, err := apiGetRequest(client, fmt.Sprintf("/v3/service_instances?names=%s", identifier))
 	if err != nil {
-		return "" ,err
+		return "", err
 	}
 
 	guid, err := jsonPath(listing, "$.resources[0].guid")
@@ -139,7 +140,7 @@ func serviceInstanceToServiceOffering(client *cfclient.Client, identifier string
 		return nil, err
 	}
 
-	offeringGUID,err  := jsonPath(plan, "$.relationships.service_offering.data.guid")
+	offeringGUID, err := jsonPath(plan, "$.relationships.service_offering.data.guid")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/service_instance_test.go
+++ b/cmd/service_instance_test.go
@@ -20,13 +20,7 @@ var _ = Describe("service_instance", func() {
 		apiServer = testfixtures.NewAPIServer()
 		cliConnection = testfixtures.NewTestCLIConnection("http://" + apiServer.ListenerAddr())
 		out = bytes.Buffer{}
-
-		apiServer.PathReturns(testfixtures.V3ServiceInstancePath, []byte(testfixtures.V3ServiceInstance))
-		apiServer.PathReturns(testfixtures.V3SpacePath, []byte(testfixtures.V3Space))
-		apiServer.PathReturns(testfixtures.V3OrgPath, []byte(testfixtures.V3Org))
-		apiServer.PathReturns(testfixtures.V3ServiceInstanceListingPath, []byte(testfixtures.V3ServiceInstanceListing))
-		apiServer.PathReturns(testfixtures.V3ServicePlanPath, []byte(testfixtures.V3ServicePlan))
-		apiServer.PathReturns(testfixtures.V3ServiceOfferingPath, []byte(testfixtures.V3ServiceOffering))
+		testfixtures.ConfigureAPIServer(apiServer)
 	})
 
 	AfterEach(func() {
@@ -35,7 +29,7 @@ var _ = Describe("service_instance", func() {
 
 	Describe("space SERVICE_INSTANCE_GUID|SERVICE_INSTANCE_NAME", func() {
 		It("gets the space the service instance belongs to when given a UUID", func() {
-			cmd := NewServiceCommand(cliConnection)
+			cmd := NewServiceInstancesCommand(cliConnection)
 			cmd.SetArgs([]string{"space", testfixtures.V3ServiceInstanceGuid})
 			cmd.SetOut(&out)
 			err := cmd.Execute()
@@ -44,8 +38,8 @@ var _ = Describe("service_instance", func() {
 			Expect(out.String()).To(Equal(testfixtures.V3Space))
 		})
 
-		It("gets the space the service instance belongs to when given a service instance name", func(){
-			cmd := NewServiceCommand(cliConnection)
+		It("gets the space the service instance belongs to when given a service instance name", func() {
+			cmd := NewServiceInstancesCommand(cliConnection)
 			cmd.SetArgs([]string{"space", testfixtures.V3ServiceInstanceName})
 			cmd.SetOut(&out)
 			err := cmd.Execute()
@@ -58,7 +52,7 @@ var _ = Describe("service_instance", func() {
 	Describe("org SERVICE_INSTANCE_GUID|SERVICE_INSTANCE_NAME", func() {
 		It("gets the org the service instance belongs to when give a UUID", func() {
 
-			cmd := NewServiceCommand(cliConnection)
+			cmd := NewServiceInstancesCommand(cliConnection)
 			cmd.SetArgs([]string{"org", testfixtures.V3ServiceInstanceGuid})
 			cmd.SetOut(&out)
 			err := cmd.Execute()
@@ -69,7 +63,7 @@ var _ = Describe("service_instance", func() {
 
 		It("gets the org the service instance belongs to when give a service instance name", func() {
 
-			cmd := NewServiceCommand(cliConnection)
+			cmd := NewServiceInstancesCommand(cliConnection)
 			cmd.SetArgs([]string{"org", testfixtures.V3ServiceInstanceName})
 			cmd.SetOut(&out)
 			err := cmd.Execute()
@@ -79,10 +73,10 @@ var _ = Describe("service_instance", func() {
 		})
 	})
 
-	Describe("plan SERVICE_INSTANCE_GUID|SERVICE_INSTANCE_NAME", func(){
+	Describe("plan SERVICE_INSTANCE_GUID|SERVICE_INSTANCE_NAME", func() {
 		It("gets the service plan the service instance is an instance of when give a UUID", func() {
 
-			cmd := NewServiceCommand(cliConnection)
+			cmd := NewServiceInstancesCommand(cliConnection)
 			cmd.SetArgs([]string{"plan", testfixtures.V3ServiceInstanceGuid})
 			cmd.SetOut(&out)
 			err := cmd.Execute()
@@ -93,7 +87,7 @@ var _ = Describe("service_instance", func() {
 
 		It("gets the service plan the service instance is an instance of when give a service instance name", func() {
 
-			cmd := NewServiceCommand(cliConnection)
+			cmd := NewServiceInstancesCommand(cliConnection)
 			cmd.SetArgs([]string{"plan", testfixtures.V3ServiceInstanceName})
 			cmd.SetOut(&out)
 			err := cmd.Execute()
@@ -103,10 +97,10 @@ var _ = Describe("service_instance", func() {
 		})
 	})
 
-	Describe("service_offering SERVICE_INSTANCE_GUID|SERVICE_INSTANCE_NAME", func(){
+	Describe("service_offering SERVICE_INSTANCE_GUID|SERVICE_INSTANCE_NAME", func() {
 		It("gets the service offering the service instance is an instance of when give a UUID", func() {
 
-			cmd := NewServiceCommand(cliConnection)
+			cmd := NewServiceInstancesCommand(cliConnection)
 			cmd.SetArgs([]string{"service_offering", testfixtures.V3ServiceInstanceGuid})
 			cmd.SetOut(&out)
 			err := cmd.Execute()
@@ -117,7 +111,7 @@ var _ = Describe("service_instance", func() {
 
 		It("gets the service offering the service instance is an instance of when give a service instance name", func() {
 
-			cmd := NewServiceCommand(cliConnection)
+			cmd := NewServiceInstancesCommand(cliConnection)
 			cmd.SetArgs([]string{"service_offering", testfixtures.V3ServiceInstanceName})
 			cmd.SetOut(&out)
 			err := cmd.Execute()

--- a/cmd/service_plan.go
+++ b/cmd/service_plan.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"fmt"
+
+	cliPlugin "code.cloudfoundry.org/cli/plugin"
+	cfclient "github.com/cloudfoundry-community/go-cfclient"
+	"github.com/spf13/cobra"
+)
+
+func NewServicePlansCommand(cliConnection cliPlugin.CliConnection) *cobra.Command {
+	return &cobra.Command{
+		Use:     "service_plan",
+		Aliases: []string{"s_p"},
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newClient(cliConnection)
+			if err != nil {
+				return err
+			}
+
+			identifier := args[1]
+			targetType := args[0]
+
+			switch targetType {
+			case "instances_of":
+				instances, err := serviceInstancesFromPlanGuid(client, identifier)
+				if err != nil {
+					return err
+				}
+				cmd.Print(string(instances))
+
+			default:
+				return fmt.Errorf("unknown relation '%s'", targetType)
+			}
+
+			return nil
+		},
+	}
+}
+
+func serviceInstancesFromPlanGuid(client *cfclient.Client, identifier string) ([]byte, error) {
+	listing, err := apiGetRequest(client, fmt.Sprintf("/v3/service_instances?per_page=5000&service_plan_guids=%s", identifier))
+
+	if err != nil {
+		return nil, err
+	}
+
+	return listing, nil
+}

--- a/cmd/service_plan_test.go
+++ b/cmd/service_plan_test.go
@@ -1,0 +1,41 @@
+package cmd_test
+
+import (
+	"bytes"
+
+	"code.cloudfoundry.org/cli/plugin"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/AP-Hunt/cf-traverse/cmd"
+	"github.com/AP-Hunt/cf-traverse/testfixtures"
+)
+
+var _ = Describe("service_plan", func() {
+	var apiServer *testfixtures.APIServer
+	var cliConnection plugin.CliConnection
+	var out bytes.Buffer
+
+	BeforeEach(func() {
+		apiServer = testfixtures.NewAPIServer()
+		cliConnection = testfixtures.NewTestCLIConnection("http://" + apiServer.ListenerAddr())
+		out = bytes.Buffer{}
+		testfixtures.ConfigureAPIServer(apiServer)
+	})
+
+	AfterEach(func() {
+		apiServer.Stop()
+	})
+
+	Describe("instances_of SERVICE_PLAN_GUID", func() {
+		It("gets all of the instances of the gievn service plan guid", func() {
+			cmd := NewServicePlansCommand(cliConnection)
+			cmd.SetArgs([]string{"instances_of", testfixtures.V3ServicePlanGuid})
+			cmd.SetOut(&out)
+			err := cmd.Execute()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.String()).To(Equal(testfixtures.V3ServiceInstancesBySinglePlanListing))
+		})
+	})
+})

--- a/plugin.go
+++ b/plugin.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/AP-Hunt/cf-traverse/version"
 	"strconv"
+
+	"github.com/AP-Hunt/cf-traverse/version"
 
 	cliPlugin "code.cloudfoundry.org/cli/plugin"
 	"github.com/AP-Hunt/cf-traverse/cmd"
@@ -18,7 +19,8 @@ func NewPlugin() *Plugin {
 
 func (p *Plugin) Run(cliConnection cliPlugin.CliConnection, args []string) {
 	root := cmd.NewRootCommand()
-	root.AddCommand(cmd.NewServiceCommand(cliConnection))
+	root.AddCommand(cmd.NewServiceInstancesCommand(cliConnection))
+	root.AddCommand(cmd.NewServicePlansCommand(cliConnection))
 
 	root.SetArgs(args[1:])
 	err := root.Execute()
@@ -42,7 +44,6 @@ func (p *Plugin) GetMetadata() cliPlugin.PluginMetadata {
 	if err != nil {
 		panic(fmt.Sprintf("cannot convert patch version '%s' to an integer", version.PATCH_VERSION))
 	}
-
 
 	return cliPlugin.PluginMetadata{
 		Name: "traverse",

--- a/testfixtures/api_service_instance.go
+++ b/testfixtures/api_service_instance.go
@@ -3,85 +3,24 @@ package testfixtures
 import "fmt"
 
 const V3ServiceInstanceGuid = "e9aca2a7-f4f9-431e-924c-664ddc236604"
+const V3ServiceInstanceAlternateGuid = "0f52de7f-b7f6-435c-9f9d-f0bca1a6f874"
 const V3ServiceInstanceName = "a-service-instance"
 
 var V3ServiceInstancePath = fmt.Sprintf("/v3/service_instances/%s", V3ServiceInstanceGuid)
-var V3ServiceInstanceListingPath = fmt.Sprintf("/v3/service_instances?names=%s", V3ServiceInstanceName)
+var V3ServiceInstanceByNameListingPath = fmt.Sprintf("/v3/service_instances?names=%s", V3ServiceInstanceName)
+var V3ServiceInstancesBySinglePlanListingPath = fmt.Sprintf("/v3/service_instances?per_page=5000&service_plan_guids=%s", V3ServicePlanGuid)
 
-var V3ServiceInstance = fmt.Sprintf(`
-{
-	"guid": "%[1]s",
-	"created_at": "2020-03-10T15:49:29Z",
-	"updated_at": "2020-03-10T15:49:29Z",
-	"name": "%[3]s",
-	"tags": [],
-	"type": "managed",
-	"maintenance_info": {
-	  "version": "1.0.0"
-	},
-	"upgrade_available": false,
-	"dashboard_url": "https://service-broker.example.org/dashboard",
-	"last_operation": {
-	  "type": "create",
-	  "state": "succeeded",
-	  "description": "Operation succeeded",
-	  "updated_at": "2020-03-10T15:49:32Z",
-	  "created_at": "2020-03-10T15:49:29Z"
-	},
-	"relationships": {
-	  "service_plan": {
-		"data": {
-		  "guid": "%[4]s"
-		}
-	  },
-	  "space": {
-		"data": {
-		  "guid": "%[2]s"
-		}
-	  }
-	},
-	"metadata": {
-	  "labels": {},
-	  "annotations": {}
-	},
-	"links": {
-	  "self": {
-		"href": "https://api.example.org/v3/service_instances/%[1]s"
-	  },
-	  "service_plan": {
-		"href": "https://api.example.org/v3/service_plans/%[4]s"
-	  },
-	  "space": {
-		"href": "https://api.example.org/v3/spaces/%[2]s"
-	  },
-	  "parameters": {
-		"href": "https://api.example.org/v3/service_instances/%[1]s/parameters"
-	  },
-	  "service_credential_bindings": {
-		"href": "https://api.example.org/v3/service_credential_bindings?service_instance_guids=%[1]s"
-	  },
-	  "service_route_bindings": {
-		"href": "https://api.example.org/v3/service_route_bindings?service_instance_guids=%[1]s"
-	  }
-	}
-  }
-`,
-	V3ServiceInstanceGuid,
-	V3SpaceGuid,
-	V3ServiceInstanceName,
-	V3ServicePlanGuid,
-)
-
-var V3ServiceInstanceListing = fmt.Sprintf(`
+var V3ServiceInstance = NewV3ServiceInstance(V3ServiceInstanceGuid, V3ServiceInstanceName, V3SpaceGuid, V3ServicePlanGuid)
+var V3ServiceInstancesByNameListing = fmt.Sprintf(`
 {
   "pagination": {
     "total_results": 1,
     "total_pages": 1,
     "first": {
-      "href": "https://api.example.org/v3/service_instances?page=1&per_page=50"
+      "href": "https://api.example.org/v3/service_instances?page=1&per_page=5000&names=%[2]s"
     },
     "last": {
-      "href": "https://api.example.org/v3/service_instances?page=1&per_page=50"
+      "href": "https://api.example.org/v3/service_instances?page=1&per_page=5000&names=%[2]s"
     },
     "next": null,
     "previous": null
@@ -91,4 +30,95 @@ var V3ServiceInstanceListing = fmt.Sprintf(`
   ]
 }
 `,
-V3ServiceInstance)
+	V3ServiceInstance,
+	V3ServiceInstanceName)
+
+var V3ServiceInstancesBySinglePlanListing = fmt.Sprintf(`
+{
+	"pagination": {
+	  "total_results": 1,
+	  "total_pages": 1,
+	  "first": {
+		"href": "https://api.example.org/v3/service_instances?page=1&per_page=50&service_plan_guids=%[3]s"
+	  },
+	  "last": {
+		"href": "https://api.example.org/v3/service_instances?page=1&per_page=50&service_plan_guids=%[3]s"
+	  },
+	  "next": null,
+	  "previous": null
+	},
+	"resources": [
+	  %[1]s
+	  %[2]s
+	]
+  }
+`,
+	V3ServiceInstance,
+	NewV3ServiceInstance(V3ServiceInstanceAlternateGuid, "b-service-instance", V3SpaceGuid, V3ServicePlanGuid),
+	V3ServicePlanGuid)
+
+func NewV3ServiceInstance(instanceGuid string, instanceName string, spaceGuid string, servicePlanGuid string) string {
+	return fmt.Sprintf(`
+	{
+		"guid": "%[1]s",
+		"created_at": "2020-03-10T15:49:29Z",
+		"updated_at": "2020-03-10T15:49:29Z",
+		"name": "%[3]s",
+		"tags": [],
+		"type": "managed",
+		"maintenance_info": {
+			"version": "1.0.0"
+		},
+		"upgrade_available": false,
+		"dashboard_url": "https://service-broker.example.org/dashboard",
+		"last_operation": {
+			"type": "create",
+			"state": "succeeded",
+			"description": "Operation succeeded",
+			"updated_at": "2020-03-10T15:49:32Z",
+			"created_at": "2020-03-10T15:49:29Z"
+		},
+		"relationships": {
+			"service_plan": {
+			"data": {
+				"guid": "%[4]s"
+			}
+			},
+			"space": {
+			"data": {
+				"guid": "%[2]s"
+			}
+			}
+		},
+		"metadata": {
+			"labels": {},
+			"annotations": {}
+		},
+		"links": {
+			"self": {
+			"href": "https://api.example.org/v3/service_instances/%[1]s"
+			},
+			"service_plan": {
+			"href": "https://api.example.org/v3/service_plans/%[4]s"
+			},
+			"space": {
+			"href": "https://api.example.org/v3/spaces/%[2]s"
+			},
+			"parameters": {
+			"href": "https://api.example.org/v3/service_instances/%[1]s/parameters"
+			},
+			"service_credential_bindings": {
+			"href": "https://api.example.org/v3/service_credential_bindings?service_instance_guids=%[1]s"
+			},
+			"service_route_bindings": {
+			"href": "https://api.example.org/v3/service_route_bindings?service_instance_guids=%[1]s"
+			}
+		}
+		}
+	`,
+		instanceGuid,
+		spaceGuid,
+		instanceName,
+		servicePlanGuid,
+	)
+}

--- a/testfixtures/configure.go
+++ b/testfixtures/configure.go
@@ -1,0 +1,22 @@
+package testfixtures
+
+// Configures the API server to serve the different
+// responses at different paths
+func ConfigureAPIServer(apiServer *APIServer) {
+	// Orgs
+	apiServer.PathReturns(V3OrgPath, []byte(V3Org))
+
+	// Service instances
+	apiServer.PathReturns(V3ServiceInstancePath, []byte(V3ServiceInstance))
+	apiServer.PathReturns(V3ServiceInstanceByNameListingPath, []byte(V3ServiceInstancesByNameListing))
+	apiServer.PathReturns(V3ServiceInstancesBySinglePlanListingPath, []byte(V3ServiceInstancesBySinglePlanListing))
+
+	// Service offerings
+	apiServer.PathReturns(V3ServiceOfferingPath, []byte(V3ServiceOffering))
+
+	// Service plans
+	apiServer.PathReturns(V3ServicePlanPath, []byte(V3ServicePlan))
+
+	// Spaces
+	apiServer.PathReturns(V3SpacePath, []byte(V3Space))
+}


### PR DESCRIPTION
Given a service plan guid, finds all instances of it.

e.g. `cf traverse service_plan instances_of SERVICE_PLAN_GUID`