### PR TITLE
Bump minor version and tag commits on push to branch

### DIFF
--- a/.github/workflows/increment_minor_version.yml
+++ b/.github/workflows/increment_minor_version.yml
@@ -1,0 +1,44 @@
+# This workflow increments the minor version 
+# when there is a push to the main branch.
+# 
+# It does not run if the commit has been tagged,
+# so that it doesn't get in to an endless loop
+# when a tagged commit gets pushed.
+on:
+    push:
+        branches:
+            - increment_version_and_create_release_on_main_merge
+        tags-ignore:
+            - "*"         
+
+name: Increment minor version
+jobs:
+    increment_minor_version:
+        name: Increment minor version
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-go@v2
+              with:
+                go-version: '^1.15'
+
+            - name: Install semver cli
+              run: go get github.com/davidrjonas/semver-cli
+
+            - name: Increment minor version
+              run: |
+                echo "Current version: $(cat version.txt)"
+                semver-cli inc minor $(cat version.txt) > version.txt
+                echo "New version: $(cat version.txt)"
+                echo "CF_TRAVERSE_VERSION=$(cat version.txt)" >> $GITHUB_ENV 
+
+            - name: Tag, commit, push
+              uses: EndBug/add-and-commit@v5
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                add: version.txt
+                author_name: "GitHub Actions on behalf of Andy Hunt"
+                author_email: "github@andyhunt.me"
+                message: "Bump version to ${{ env.CF_TRAVERSE_VERSION }}"
+                tag: "${{ env.CF_TRAVERSE_VERSION }} --force"

--- a/.github/workflows/increment_minor_version.yml
+++ b/.github/workflows/increment_minor_version.yml
@@ -7,7 +7,7 @@
 on:
     push:
         branches:
-            - increment_version_and_create_release_on_main_merge
+            - main
         tags-ignore:
             - "*"         
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,3 +1,5 @@
+# This workflow runs the suite of tests when a PR is 
+# created or modified.
 on: pull_request
 name: Pull Request
 jobs:


### PR DESCRIPTION
Adds a GitHub Actions workflow that bumps the minor version and commits it with a matching tag, when an untagged commit is pushed to the branch.

Initially, the branch is set to `increment_version_and_create_release_on_main_merge` whilst its tested. A future commit will change it to "main".