### PR TITLE
Cut release on version bump

### DIFF
--- a/.github/workflows/cut_release_on_version_bump.yml
+++ b/.github/workflows/cut_release_on_version_bump.yml
@@ -1,0 +1,48 @@
+# This workflow creates a release in GitHub
+# whenever the version is bumped, indicated 
+# by a new tag being created
+on:
+    push:
+        branches:
+            - cut_release_on_version_bump
+        tags: 
+            - "*"
+
+name: Cut release
+jobs:
+    cut_release:
+        name: Cut release
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-go@v2
+              with:
+                go-version: '^1.15'
+
+            - name: Compile release
+              run: make release
+            
+            - name: Create release
+              id: create_release
+              uses: actions/create-release@v1
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                tag_name: ${{ github.ref }}
+                release_name: "Version ${{github.ref}}"
+                draft: false
+                prerelease: false
+
+            - name: Put version in env
+              run: echo "CF_TRAVERSE_VERSION=$(cat version.txt)" >> $GITHUB_ENV 
+
+            - name: Upload assets
+              id: upload_assets
+              uses: actions/upload-release-asset@v1
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                upload_url: ${{ steps.create_release.outputs.upload_url }}
+                asset_path: "cf-traverse-${{ env.CF_TRAVERSE_VERSION }}.tar.gz"
+                asset_name: "cf-traverse-${{ env.CF_TRAVERSE_VERSION }}.tar.gz"
+                asset_content_type: application/gzip

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 VERSION_MAJOR := $(shell semver-cli get major $$(cat ./version.txt))
 VERSION_MINOR := $(shell semver-cli get minor $$(cat ./version.txt))
 VERSION_PATCH := $(shell semver-cli get patch $$(cat ./version.txt))
+GO_OS := $(shell go env GOOS)
+GO_ARCH := $(shell go env GOARCH)
 
 build:
 	go build \
@@ -10,3 +12,10 @@ build:
 
 install: build
 	cf install-plugin -f ./bin/cf-traverse
+
+release: 
+	@go build \
+      -o "bin/release/cf-traverse-${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}-${GO_OS}-${GO_ARCH}" \
+      -ldflags="-X 'github.com/AP-Hunt/cf-traverse/version.MAJOR_VERSION=${VERSION_MAJOR}' -X 'github.com/AP-Hunt/cf-traverse/version.MINOR_VERSION=${VERSION_MINOR}' -X 'github.com/AP-Hunt/cf-traverse/version.PATCH_VERSION=${VERSION_PATCH}'" \
+      . && \
+      tar czf "cf-traverse-${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}.tar.gz" -C "bin/release/" .


### PR DESCRIPTION
Creates a workflow to create a release on tagging. The workflow compiles cf-traverse for release, creates a release on GitHub, and uploads the compiled asset to the release