### PR TITLE
Enable getting all instances of a service offering

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ for the source entity. The table below shows all the supported source entities, 
             <td rowspan="2">A service plan guid</td>
         </tr>
         <tr><td>instances_of</td></tr>
+        <!-- Service offering -->
+        <tr>
+            <td rowspan="2">service_offering</td>
+            <td rowspan="2">A service offering guid, or service offering name</td>
+        </tr>
+        <tr><td>instances_of</td></tr>
     </tbody>
 </table>
 

--- a/cmd/service_instance.go
+++ b/cmd/service_instance.go
@@ -24,6 +24,9 @@ func NewServiceInstancesCommand(cliConnection cliPlugin.CliConnection) *cobra.Co
 
 			if !isUUID(identifier) {
 				identifier, err = serviceInstanceGuidFromName(client, identifier)
+				if err != nil {
+					return err
+				}
 			}
 
 			targetType := args[0]
@@ -67,7 +70,7 @@ func serviceInstanceGuidFromName(client *cfclient.Client, identifier string) (st
 		return "", err
 	}
 
-	guid, err := jsonPath(listing, "$.resources[0].guid")
+	guid, err := jsonPathString(listing, "$.resources[0].guid")
 	if err != nil {
 		return "", err
 	}
@@ -82,7 +85,7 @@ func serviceInstanceToSpace(client *cfclient.Client, identifier string) ([]byte,
 		return nil, err
 	}
 
-	spaceGUID, err := jsonPath(svcInstance, "$.relationships.space.data.guid")
+	spaceGUID, err := jsonPathString(svcInstance, "$.relationships.space.data.guid")
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +104,7 @@ func serviceInstanceToOrg(client *cfclient.Client, identifier string) ([]byte, e
 		return nil, err
 	}
 
-	orgGUID, err := jsonPath(space, "$.relationships.organization.data.guid")
+	orgGUID, err := jsonPathString(space, "$.relationships.organization.data.guid")
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +123,7 @@ func serviceInstanceToPlan(client *cfclient.Client, identifier string) ([]byte, 
 		return nil, err
 	}
 
-	planGUID, err := jsonPath(svcInstance, "$.relationships.service_plan.data.guid")
+	planGUID, err := jsonPathString(svcInstance, "$.relationships.service_plan.data.guid")
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +143,7 @@ func serviceInstanceToServiceOffering(client *cfclient.Client, identifier string
 		return nil, err
 	}
 
-	offeringGUID, err := jsonPath(plan, "$.relationships.service_offering.data.guid")
+	offeringGUID, err := jsonPathString(plan, "$.relationships.service_offering.data.guid")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/service_offering.go
+++ b/cmd/service_offering.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	cliPlugin "code.cloudfoundry.org/cli/plugin"
+	"fmt"
+	"github.com/cloudfoundry-community/go-cfclient"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+func NewServiceOfferingsCommand(cliConnection cliPlugin.CliConnection) *cobra.Command {
+	return &cobra.Command{
+		Use: "service_offering",
+		Aliases: []string{"s_o"},
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newClient(cliConnection)
+			if err != nil {
+				return err
+			}
+
+			identifier := args[1]
+			targetType := args[0]
+
+			if !isUUID(identifier) {
+				identifier, err = serviceOfferingGuidFromName(client, identifier)
+				if err != nil {
+					return err
+				}
+			}
+
+			switch targetType {
+			default:
+				return fmt.Errorf("unknown relation '%s'", targetType)
+			case "instances_of":
+				instances, err := serviceInstancesFromOfferingGuid(client, identifier)
+				if err != nil {
+					return err
+				}
+				cmd.Print(string(instances))
+			}
+
+			return nil
+		},
+	}
+}
+
+func serviceOfferingGuidFromName(client *cfclient.Client, identifier string) (string, error) {
+	listing, err := apiGetRequest(client, fmt.Sprintf("/v3/service_offerings?names=%s", identifier))
+	if err != nil {
+		return "", err
+	}
+
+	guid, err := jsonPathString(listing, "$.resources[0].guid")
+	if err != nil {
+		return "", err
+	}
+
+	return guid, nil
+}
+
+func serviceInstancesFromOfferingGuid(client *cfclient.Client, identifier string) ([]byte, error) {
+	servicePlans, err := plansFromOfferingGuid(client, identifier)
+	if err != nil {
+		return nil, err
+	}
+
+	servicePlanGuids, err := jsonPathStringSlice(servicePlans, "$.resources[*].guid")
+	if err != nil {
+		return nil, err
+	}
+
+	planCsv := strings.Join(servicePlanGuids, ",")
+	instancesPath := fmt.Sprintf("/v3/service_instances?per_page=5000&service_plan_guids=%s", planCsv)
+	instances, err := apiGetRequest(client, instancesPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return instances, nil
+}
+
+func plansFromOfferingGuid(client *cfclient.Client, identifier string) ([]byte, error) {
+	plans, err := apiGetRequest(client, fmt.Sprintf("/v3/service_plans?per_page=5000&service_offering_guids=%s", identifier))
+	if err != nil {
+		return nil, err
+	}
+	return plans, nil
+}

--- a/cmd/service_offering_test.go
+++ b/cmd/service_offering_test.go
@@ -1,0 +1,49 @@
+package cmd_test
+
+import (
+	"bytes"
+	"code.cloudfoundry.org/cli/plugin"
+	"github.com/AP-Hunt/cf-traverse/testfixtures"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/AP-Hunt/cf-traverse/cmd"
+)
+
+var _ = Describe("service_offering", func() {
+	var apiServer *testfixtures.APIServer
+	var cliConnection plugin.CliConnection
+	var out bytes.Buffer
+
+	BeforeEach(func() {
+		apiServer = testfixtures.NewAPIServer()
+		cliConnection = testfixtures.NewTestCLIConnection("http://" + apiServer.ListenerAddr())
+		out = bytes.Buffer{}
+		testfixtures.ConfigureAPIServer(apiServer)
+	})
+
+	AfterEach(func() {
+		apiServer.Stop()
+	})
+
+	Describe("instances_of SERVICE_OFFERING_GUID|SERVICE_OFFERING_NAME", func() {
+		It("gets all of the instances of all of the service plans belonging to the given service offering guid", func() {
+			cmd := NewServiceOfferingsCommand(cliConnection)
+			cmd.SetArgs([]string{"instances_of", testfixtures.V3ServiceOfferingGuid})
+			cmd.SetOut(&out)
+			err := cmd.Execute()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.String()).To(Equal(testfixtures.V3ServiceInstancesByMultiplePlanListing))
+		})
+
+		It("gets all of the instances of all of the service plans belonging to the given service offering name", func() {
+			cmd := NewServiceOfferingsCommand(cliConnection)
+			cmd.SetArgs([]string{"instances_of", testfixtures.V3ServiceOfferingName})
+			cmd.SetOut(&out)
+			err := cmd.Execute()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.String()).To(Equal(testfixtures.V3ServiceInstancesByMultiplePlanListing))
+		})
+	})
+})

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -25,7 +25,7 @@ func apiGetRequest(client *cfclient.Client, path string) ([]byte, error) {
 	return respBytes, nil
 }
 
-func jsonPath(json []byte, path string) (string, error) {
+func jsonPathString(json []byte, path string) (string, error) {
 	root, err := ajson.Unmarshal(json)
 	if err != nil {
 		return "", err
@@ -49,6 +49,34 @@ func jsonPath(json []byte, path string) (string, error) {
 		return "", err
 	}
 	return nodeVal.(string), nil
+}
+
+func jsonPathStringSlice(json []byte, path string) ([]string, error) {
+	root, err := ajson.Unmarshal(json)
+	if err != nil {
+		return nil, err
+	}
+
+	nodes, err := root.JSONPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(nodes) == 0 {
+		return []string{}, nil
+	}
+
+	var result []string
+	for _, node := range nodes {
+		nodeVal, err := node.Value()
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, nodeVal.(string))
+	}
+
+	return result, nil
 }
 
 func newClient(cliConnection cliPlugin.CliConnection) (*cfclient.Client, error) {

--- a/plugin.go
+++ b/plugin.go
@@ -21,6 +21,7 @@ func (p *Plugin) Run(cliConnection cliPlugin.CliConnection, args []string) {
 	root := cmd.NewRootCommand()
 	root.AddCommand(cmd.NewServiceInstancesCommand(cliConnection))
 	root.AddCommand(cmd.NewServicePlansCommand(cliConnection))
+	root.AddCommand(cmd.NewServiceOfferingsCommand(cliConnection))
 
 	root.SetArgs(args[1:])
 	err := root.Execute()

--- a/testfixtures/apI_service_plan.go
+++ b/testfixtures/apI_service_plan.go
@@ -3,9 +3,38 @@ package testfixtures
 import "fmt"
 
 const V3ServicePlanGuid = "2b5fa5bf-eafa-4ae3-9727-e1f6bcc622ee"
+const V3ServicePlanAlternateGuid = "8a138e97-42d6-46f6-be0f-5347d23b7e8e"
 
 var V3ServicePlanPath = fmt.Sprintf("/v3/service_plans/%s", V3ServicePlanGuid)
-var V3ServicePlan = fmt.Sprintf(`
+var V3ServicePlansForOfferingPath = fmt.Sprintf("/v3/service_plans?per_page=5000&service_offering_guids=%s", V3ServiceOfferingGuid)
+
+var V3ServicePlan = NewV3ServicePlan(V3ServicePlanGuid, V3ServiceOfferingGuid)
+var V3ServicePlansForOfferingListing = fmt.Sprintf(`
+{
+  "pagination": {
+    "total_results": 2,
+    "total_pages": 1,
+    "first": {
+      "href": "https://api.example.org/v3/service_plans?page=1&per_page=5000&service_offering_guids=%[1]s"
+    },
+    "last": {
+      "href": "https://api.example.org/v3/service_plans?page=2&per_page=5000&service_offering_guids=%[1]s"
+    },
+    "next": null,
+    "previous": null
+  },
+  "resources": [
+	%[2]s,
+	%[3]s
+  ]
+}`,
+V3ServiceOfferingGuid,
+V3ServicePlan,
+NewV3ServicePlan(V3ServicePlanAlternateGuid, V3ServiceOfferingGuid),
+)
+
+func NewV3ServicePlan(planGuid string, offeringGuid string) string  {
+	return fmt.Sprintf(`
 {
   "guid": "%[1]s",
   "name": "my_big_service_plan",
@@ -81,5 +110,6 @@ var V3ServicePlan = fmt.Sprintf(`
   }
 }
 `,
-V3ServicePlanGuid,
-V3ServiceOfferingGuid)
+		planGuid,
+		offeringGuid)
+}

--- a/testfixtures/api_service_instance.go
+++ b/testfixtures/api_service_instance.go
@@ -9,6 +9,7 @@ const V3ServiceInstanceName = "a-service-instance"
 var V3ServiceInstancePath = fmt.Sprintf("/v3/service_instances/%s", V3ServiceInstanceGuid)
 var V3ServiceInstanceByNameListingPath = fmt.Sprintf("/v3/service_instances?names=%s", V3ServiceInstanceName)
 var V3ServiceInstancesBySinglePlanListingPath = fmt.Sprintf("/v3/service_instances?per_page=5000&service_plan_guids=%s", V3ServicePlanGuid)
+var V3ServiceInstancesByMultiplePlanListingPath = fmt.Sprintf("/v3/service_instances?per_page=5000&service_plan_guids=%s,%s", V3ServicePlanGuid, V3ServicePlanAlternateGuid)
 
 var V3ServiceInstance = NewV3ServiceInstance(V3ServiceInstanceGuid, V3ServiceInstanceName, V3SpaceGuid, V3ServicePlanGuid)
 var V3ServiceInstancesByNameListing = fmt.Sprintf(`
@@ -48,7 +49,7 @@ var V3ServiceInstancesBySinglePlanListing = fmt.Sprintf(`
 	  "previous": null
 	},
 	"resources": [
-	  %[1]s
+	  %[1]s,
 	  %[2]s
 	]
   }
@@ -56,6 +57,32 @@ var V3ServiceInstancesBySinglePlanListing = fmt.Sprintf(`
 	V3ServiceInstance,
 	NewV3ServiceInstance(V3ServiceInstanceAlternateGuid, "b-service-instance", V3SpaceGuid, V3ServicePlanGuid),
 	V3ServicePlanGuid)
+
+var V3ServiceInstancesByMultiplePlanListing = fmt.Sprintf(`
+{
+	"pagination": {
+	  "total_results": 1,
+	  "total_pages": 1,
+	  "first": {
+		"href": "https://api.example.org/v3/service_instances?page=1&per_page=50&service_plan_guids=%[3]s,%[4]s"
+	  },
+	  "last": {
+		"href": "https://api.example.org/v3/service_instances?page=1&per_page=50&service_plan_guids=%[3]s,%[4]s"
+	  },
+	  "next": null,
+	  "previous": null
+	},
+	"resources": [
+	  %[1]s,
+	  %[2]s
+	]
+  }
+`,
+	V3ServiceInstance,
+	NewV3ServiceInstance(V3ServiceInstanceAlternateGuid, "b-service-instance", V3SpaceGuid, V3ServicePlanAlternateGuid),
+	V3ServicePlanGuid,
+	V3ServicePlanAlternateGuid)
+
 
 func NewV3ServiceInstance(instanceGuid string, instanceName string, spaceGuid string, servicePlanGuid string) string {
 	return fmt.Sprintf(`

--- a/testfixtures/api_service_offering.go
+++ b/testfixtures/api_service_offering.go
@@ -3,12 +3,15 @@ package testfixtures
 import "fmt"
 
 const V3ServiceOfferingGuid = "38c435ac-87a5-4c19-9794-1ab3e99bd97c"
+const V3ServiceOfferingName = "a-service-offering"
 
 var V3ServiceOfferingPath = fmt.Sprintf("/v3/service_offerings/%s", V3ServiceOfferingGuid)
+var V3ServiceOfferingByNamePath = fmt.Sprintf("/v3/service_offerings?names=%s", V3ServiceOfferingName)
+
 var V3ServiceOffering = fmt.Sprintf(`
 {
   "guid": "%[1]s",
-  "name": "my_service_offering",
+  "name": "%[2]s",
   "description": "Provides my service",
   "available": true,
   "tags": ["relational", "caching"],
@@ -54,4 +57,27 @@ var V3ServiceOffering = fmt.Sprintf(`
   }
 }
 `,
-V3ServiceOfferingGuid)
+V3ServiceOfferingGuid,
+V3ServiceOfferingName)
+
+var V3ServiceOfferingByNameListing = fmt.Sprintf(`
+{
+  "pagination": {
+    "total_results": 1,
+    "total_pages": 1,
+    "first": {
+      "href": "https://api.example.org/v3/service_offerings?page=1&per_page=1&names=%[2]s"
+    },
+    "last": {
+      "href": "https://api.example.org/v3/service_offerings?page=1&per_page=1&names=%[2]s"
+    },
+    "next": null,
+    "previous": null
+  },
+  "resources": [
+	%[1]s
+  ]
+}
+`,
+V3ServiceOffering,
+V3ServiceOfferingName)

--- a/testfixtures/configure.go
+++ b/testfixtures/configure.go
@@ -10,12 +10,15 @@ func ConfigureAPIServer(apiServer *APIServer) {
 	apiServer.PathReturns(V3ServiceInstancePath, []byte(V3ServiceInstance))
 	apiServer.PathReturns(V3ServiceInstanceByNameListingPath, []byte(V3ServiceInstancesByNameListing))
 	apiServer.PathReturns(V3ServiceInstancesBySinglePlanListingPath, []byte(V3ServiceInstancesBySinglePlanListing))
+	apiServer.PathReturns(V3ServiceInstancesByMultiplePlanListingPath, []byte(V3ServiceInstancesByMultiplePlanListing))
 
 	// Service offerings
 	apiServer.PathReturns(V3ServiceOfferingPath, []byte(V3ServiceOffering))
+	apiServer.PathReturns(V3ServiceOfferingByNamePath, []byte(V3ServiceOfferingByNameListing))
 
 	// Service plans
 	apiServer.PathReturns(V3ServicePlanPath, []byte(V3ServicePlan))
+	apiServer.PathReturns(V3ServicePlansForOfferingPath, []byte(V3ServicePlansForOfferingListing))
 
 	// Spaces
 	apiServer.PathReturns(V3SpacePath, []byte(V3Space))

--- a/testfixtures/server.go
+++ b/testfixtures/server.go
@@ -3,6 +3,7 @@ package testfixtures
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 )
 
 type APIServer struct {
@@ -23,7 +24,11 @@ func NewAPIServer() *APIServer {
 
 		fullPath := path
 		if query != "" {
-			fullPath = fullPath+"?"+query
+			unescapedQuery, err := url.QueryUnescape(query)
+			if err != nil {
+				panic(err)
+			}
+			fullPath = fullPath+"?"+unescapedQuery
 		}
 		if response, ok := apiServer.pathResponses[fullPath]; ok {
 			w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Given a service offering name or guid, CF traverse can now fetch all instances
of that service offering.

It is currently limited to 5000 services, as per the APIs maximum number of
items per page.