### PR TITLE
Compile for multiple targets

### DIFF
--- a/.github/workflows/increment_minor_version_and_create_release.yml
+++ b/.github/workflows/increment_minor_version_and_create_release.yml
@@ -26,7 +26,7 @@ jobs:
             - name: Install dependencies
               run: |
                 go mod vendor
-                 go get github.com/davidrjonas/semver-cli
+                go get github.com/davidrjonas/semver-cli
   
             - name: Increment minor version
               run: |
@@ -62,11 +62,7 @@ jobs:
 
             - name: Upload assets
               id: upload_assets
-              uses: actions/upload-release-asset@v1
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                upload_url: ${{ steps.create_release.outputs.upload_url }}
-                asset_path: "cf-traverse-${{ env.CF_TRAVERSE_VERSION }}.tar.gz"
-                asset_name: "cf-traverse-${{ env.CF_TRAVERSE_VERSION }}.tar.gz"
-                asset_content_type: application/gzip              
+              run: |
+                gh release upload "${CF_TRAVERSE_VERSION}" ./bin/release/*

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 VERSION_MAJOR := $(shell semver-cli get major $$(cat ./version.txt))
 VERSION_MINOR := $(shell semver-cli get minor $$(cat ./version.txt))
 VERSION_PATCH := $(shell semver-cli get patch $$(cat ./version.txt))
-GO_OS := $(shell go env GOOS)
-GO_ARCH := $(shell go env GOARCH)
+XCOMPILE_PLATS := darwin/amd64 linux/386 linux/amd64 windows/386 windows/amd64
 
 build:
 	go build \
@@ -13,10 +12,12 @@ build:
 install: build
 	cf install-plugin -f ./bin/cf-traverse
 
-release: 
-	go build \
-      -o "bin/release/cf-traverse-${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}-${GO_OS}-${GO_ARCH}" \
+release:
+	CGO_ENABLED=0 \
+	gox \
+      -output "bin/release/cf-traverse-${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}-{{.OS}}-{{.Arch}}" \
       -ldflags="-X 'github.com/AP-Hunt/cf-traverse/version.MAJOR_VERSION=${VERSION_MAJOR}' -X 'github.com/AP-Hunt/cf-traverse/version.MINOR_VERSION=${VERSION_MINOR}' -X 'github.com/AP-Hunt/cf-traverse/version.PATCH_VERSION=${VERSION_PATCH}'" \
+      -osarch="${XCOMPILE_PLATS}" \
       . && \
       cd bin/release && \
       tar czf "../../cf-traverse-${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}.tar.gz" *

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	code.cloudfoundry.org/cli v7.1.0+incompatible
 	github.com/cloudfoundry-community/go-cfclient v0.0.0-20201123235753-4f46d6348a05
 	github.com/davidrjonas/semver-cli v0.0.0-20200305203455-0b3cebbaa360 // indirect
+	github.com/mitchellh/gox v1.0.1 // indirect
 	github.com/onsi/ginkgo v1.14.2
 	github.com/onsi/gomega v1.10.4
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -168,6 +168,8 @@ github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerX
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.0.0 h1:21MVWPKDphxa7ineQQTrCU5brh7OuVVAzGOCnnCPtE8=
+github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -209,6 +211,9 @@ github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
+github.com/mitchellh/gox v1.0.1 h1:x0jD3dcHk9a9xPSDN6YEL4xL6Qz0dvNYm8yZqui5chI=
+github.com/mitchellh/gox v1.0.1/go.mod h1:ED6BioOGXMswlXa2zxfh/xdd5QhwYliBFn9V18Ap4z4=
+github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=


### PR DESCRIPTION
Previously `make release` would compile for the system it was running on only. This isn't very helpful for Mac and Windows users.  It now compiles for a variety of targets.

Binaries are also uploaded to the release.
