### PR TITLE
Format service instance name, org name, and space name in one command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,9 +9,6 @@ func NewRootCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "traverse",
 		Aliases: []string{"tr"},
-
-		Run: func(cmd *cobra.Command, args []string) {
-		},
 	}
 
 	cmd.SetOut(os.Stdout)

--- a/cmd/service_instance.go
+++ b/cmd/service_instance.go
@@ -10,10 +10,25 @@ import (
 
 func NewServiceInstancesCommand(cliConnection cliPlugin.CliConnection) *cobra.Command {
 
-	return &cobra.Command{
+	rootCmd := &cobra.Command{
 		Use:     "service_instance",
 		Aliases: []string{"s_i"},
-		Args:    cobra.ExactArgs(2),
+		SilenceUsage: true,
+		TraverseChildren: true,
+	}
+
+	rootCmd.AddCommand(newServiceInstanceToSpaceCommand(cliConnection))
+	rootCmd.AddCommand(newServiceInstanceToOrgCommand(cliConnection))
+	rootCmd.AddCommand(newServiceInstanceToPlanCommand(cliConnection))
+	rootCmd.AddCommand(newServiceInstanceToServiceOfferingCommand(cliConnection))
+
+	return rootCmd
+}
+
+func newServiceInstanceToSpaceCommand(cliConnection cliPlugin.CliConnection) *cobra.Command {
+	return &cobra.Command{
+		Use: "space",
+		Args: cobra.ExactArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := newClient(cliConnection)
@@ -21,7 +36,7 @@ func NewServiceInstancesCommand(cliConnection cliPlugin.CliConnection) *cobra.Co
 				return err
 			}
 
-			identifier := args[1]
+			identifier := args[0]
 
 			if !isUUID(identifier) {
 				identifier, err = serviceInstanceGuidFromName(client, identifier)
@@ -30,36 +45,101 @@ func NewServiceInstancesCommand(cliConnection cliPlugin.CliConnection) *cobra.Co
 				}
 			}
 
-			targetType := args[0]
-			switch targetType {
-			case "space":
-				space, err := serviceInstanceToSpace(client, identifier)
-				if err != nil {
-					return err
-				}
-				cmd.Print(string(space))
-			case "org":
-				org, err := serviceInstanceToOrg(client, identifier)
-				if err != nil {
-					return err
-				}
-				cmd.Print(string(org))
-			case "plan":
-				plan, err := serviceInstanceToPlan(client, identifier)
-				if err != nil {
-					return err
-				}
-				cmd.Print(string(plan))
-			case "service_offering":
-				offering, err := serviceInstanceToServiceOffering(client, identifier)
-				if err != nil {
-					return err
-				}
-				cmd.Print(string(offering))
-			default:
-				return fmt.Errorf("unknown relation '%s'", targetType)
+			space, err := serviceInstanceToSpace(client, identifier)
+			if err != nil {
+				return err
+			}
+			cmd.Print(string(space))
+			return nil
+		},
+	}
+}
+
+func newServiceInstanceToOrgCommand(cliConnection cliPlugin.CliConnection) *cobra.Command {
+	return &cobra.Command{
+		Use: "org",
+		Args: cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newClient(cliConnection)
+			if err != nil {
+				return err
 			}
 
+			identifier := args[0]
+
+			if !isUUID(identifier) {
+				identifier, err = serviceInstanceGuidFromName(client, identifier)
+				if err != nil {
+					return err
+				}
+			}
+
+			org, err := serviceInstanceToOrg(client, identifier)
+			if err != nil {
+				return err
+			}
+			cmd.Print(string(org))
+			return nil
+		},
+	}
+}
+
+func newServiceInstanceToPlanCommand(cliConnection cliPlugin.CliConnection) *cobra.Command {
+	return &cobra.Command{
+		Use: "plan",
+		Args: cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newClient(cliConnection)
+			if err != nil {
+				return err
+			}
+
+			identifier := args[0]
+
+			if !isUUID(identifier) {
+				identifier, err = serviceInstanceGuidFromName(client, identifier)
+				if err != nil {
+					return err
+				}
+			}
+
+			plan, err := serviceInstanceToPlan(client, identifier)
+			if err != nil {
+				return err
+			}
+			cmd.Print(string(plan))
+			return nil
+		},
+	}
+}
+
+func newServiceInstanceToServiceOfferingCommand(cliConnection cliPlugin.CliConnection) *cobra.Command {
+	return &cobra.Command{
+		Use: "service_offering",
+		Args: cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newClient(cliConnection)
+			if err != nil {
+				return err
+			}
+
+			identifier := args[0]
+
+			if !isUUID(identifier) {
+				identifier, err = serviceInstanceGuidFromName(client, identifier)
+				if err != nil {
+					return err
+				}
+			}
+
+			offering, err := serviceInstanceToServiceOffering(client, identifier)
+			if err != nil {
+				return err
+			}
+			cmd.Print(string(offering))
 			return nil
 		},
 	}

--- a/cmd/service_instance.go
+++ b/cmd/service_instance.go
@@ -14,6 +14,7 @@ func NewServiceInstancesCommand(cliConnection cliPlugin.CliConnection) *cobra.Co
 	rootCmd := &cobra.Command{
 		Use:     "service_instance",
 		Aliases: []string{"s_i"},
+		Short: "Find relations of a service instance",
 		SilenceUsage: true,
 		TraverseChildren: true,
 	}
@@ -31,6 +32,7 @@ func newServiceInstanceToSpaceCommand(cliConnection cliPlugin.CliConnection) *co
 	return &cobra.Command{
 		Use: "space",
 		Args: cobra.ExactArgs(1),
+		Short: "Find the space to which a service instance belongs",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := newClient(cliConnection)
@@ -61,6 +63,7 @@ func newServiceInstanceToOrgCommand(cliConnection cliPlugin.CliConnection) *cobr
 	return &cobra.Command{
 		Use: "org",
 		Args: cobra.ExactArgs(1),
+		Short: "Find the organization to which the service instance belongs",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := newClient(cliConnection)
@@ -92,6 +95,7 @@ func newServiceInstanceToPlanCommand(cliConnection cliPlugin.CliConnection) *cob
 		Use: "plan",
 		Args: cobra.ExactArgs(1),
 		SilenceUsage: true,
+		Short: "Find the service plan that the service instance is an instance of",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := newClient(cliConnection)
 			if err != nil {
@@ -122,6 +126,7 @@ func newServiceInstanceToServiceOfferingCommand(cliConnection cliPlugin.CliConne
 		Use: "service_offering",
 		Args: cobra.ExactArgs(1),
 		SilenceUsage: true,
+		Short: "Find which service offering the service instance is an instance of",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := newClient(cliConnection)
 			if err != nil {
@@ -152,6 +157,7 @@ func newServiceInstanceOrgSpaceNameCommand(cliConnection cliPlugin.CliConnection
 	cmd := &cobra.Command{
 		Use: "org_space_name -d|--delimiter",
 		Args: cobra.ExactArgs(1),
+		Short: "Format the service instance name, organization name, and space name for the service instance. E.g. `org/space/instance_name`",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := newClient(cliConnection)

--- a/cmd/service_instance_test.go
+++ b/cmd/service_instance_test.go
@@ -2,6 +2,7 @@ package cmd_test
 
 import (
 	"bytes"
+	"fmt"
 
 	"code.cloudfoundry.org/cli/plugin"
 	. "github.com/AP-Hunt/cf-traverse/cmd"
@@ -118,6 +119,37 @@ var _ = Describe("service_instance", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(out.String()).To(Equal(testfixtures.V3ServiceOffering))
+		})
+	})
+
+	Describe("org_space_name --delimiter '/' SERVICE_INSTANCE_GUID|SERVICE_INSTANCE_NAME", func(){
+		It("returns an error when not given a delimiter", func() {
+			cmd := NewServiceInstancesCommand(cliConnection)
+			cmd.SetArgs([]string{"org_space_name", testfixtures.V3ServiceInstanceGuid})
+			cmd.SetOut(&out)
+			err := cmd.Execute()
+
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns the org name, space name, and service name of the service instance, separated by the delimiter, when given a UUID", func() {
+			cmd := NewServiceInstancesCommand(cliConnection)
+			cmd.SetArgs([]string{"org_space_name", "-d", "/", testfixtures.V3ServiceInstanceGuid})
+			cmd.SetOut(&out)
+			err := cmd.Execute()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.String()).To(Equal(fmt.Sprintf("%s/%s/%s", testfixtures.V3OrgName, testfixtures.V3SpaceName, testfixtures.V3ServiceInstanceName)))
+		})
+
+		It("returns the org name, space name, and service name of the service instance, separated by the delimiter, when given a UUID", func() {
+			cmd := NewServiceInstancesCommand(cliConnection)
+			cmd.SetArgs([]string{"org_space_name", "-d", "/", testfixtures.V3ServiceInstanceName})
+			cmd.SetOut(&out)
+			err := cmd.Execute()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.String()).To(Equal(fmt.Sprintf("%s/%s/%s", testfixtures.V3OrgName, testfixtures.V3SpaceName, testfixtures.V3ServiceInstanceName)))
 		})
 	})
 })

--- a/testfixtures/api_org.go
+++ b/testfixtures/api_org.go
@@ -3,6 +3,7 @@ package testfixtures
 import "fmt"
 
 const V3OrgGuid = "13200e2e-cb27-4c3e-b9fe-393d20370677"
+const V3OrgName = "an-org"
 
 var V3OrgPath = fmt.Sprintf("/v3/organizations/%s", V3OrgGuid)
 var V3Org = fmt.Sprintf(`
@@ -10,7 +11,7 @@ var V3Org = fmt.Sprintf(`
 	"guid": "%[1]s",
 	"created_at": "2017-02-01T01:33:58Z",
 	"updated_at": "2017-02-01T01:33:58Z",
-	"name": "my-organization",
+	"name": "%[2]s",
 	"suspended": false,
 	"relationships": {
 	  "quota": {
@@ -39,4 +40,5 @@ var V3Org = fmt.Sprintf(`
 	}
   }
 `,
-	V3OrgGuid)
+	V3OrgGuid,
+	V3OrgName)

--- a/testfixtures/api_service_instance.go
+++ b/testfixtures/api_service_instance.go
@@ -7,11 +7,14 @@ const V3ServiceInstanceAlternateGuid = "0f52de7f-b7f6-435c-9f9d-f0bca1a6f874"
 const V3ServiceInstanceName = "a-service-instance"
 
 var V3ServiceInstancePath = fmt.Sprintf("/v3/service_instances/%s", V3ServiceInstanceGuid)
+var V3ServiceInstanceWithOrgAndSpaceNamePath = fmt.Sprintf("/v3/service_instances/%s?fields[space]=name&fields[space.organization]=name", V3ServiceInstanceGuid)
 var V3ServiceInstanceByNameListingPath = fmt.Sprintf("/v3/service_instances?names=%s", V3ServiceInstanceName)
 var V3ServiceInstancesBySinglePlanListingPath = fmt.Sprintf("/v3/service_instances?per_page=5000&service_plan_guids=%s", V3ServicePlanGuid)
 var V3ServiceInstancesByMultiplePlanListingPath = fmt.Sprintf("/v3/service_instances?per_page=5000&service_plan_guids=%s,%s", V3ServicePlanGuid, V3ServicePlanAlternateGuid)
 
 var V3ServiceInstance = NewV3ServiceInstance(V3ServiceInstanceGuid, V3ServiceInstanceName, V3SpaceGuid, V3ServicePlanGuid)
+var V3ServiceInstanceWithOrgAndSpaceName = NewV3ServiceInstanceWithOrgAndSpaceName(V3ServiceInstanceGuid, V3ServiceInstanceName, V3SpaceGuid, V3ServicePlanGuid, V3OrgName, V3SpaceName)
+
 var V3ServiceInstancesByNameListing = fmt.Sprintf(`
 {
   "pagination": {
@@ -147,5 +150,88 @@ func NewV3ServiceInstance(instanceGuid string, instanceName string, spaceGuid st
 		spaceGuid,
 		instanceName,
 		servicePlanGuid,
+	)
+}
+
+func NewV3ServiceInstanceWithOrgAndSpaceName(
+	instanceGuid string,
+	instanceName string,
+	spaceGuid string,
+	servicePlanGuid string,
+	orgName string,
+	spaceName string,
+) string  {
+	return fmt.Sprintf(`
+	{
+		"guid": "%[1]s",
+		"created_at": "2020-03-10T15:49:29Z",
+		"updated_at": "2020-03-10T15:49:29Z",
+		"name": "%[3]s",
+		"tags": [],
+		"type": "managed",
+		"maintenance_info": {
+			"version": "1.0.0"
+		},
+		"upgrade_available": false,
+		"dashboard_url": "https://service-broker.example.org/dashboard",
+		"last_operation": {
+			"type": "create",
+			"state": "succeeded",
+			"description": "Operation succeeded",
+			"updated_at": "2020-03-10T15:49:32Z",
+			"created_at": "2020-03-10T15:49:29Z"
+		},
+		"relationships": {
+			"service_plan": {
+			"data": {
+				"guid": "%[4]s"
+			}
+			},
+			"space": {
+			"data": {
+				"guid": "%[2]s"
+			}
+			}
+		},
+		"metadata": {
+			"labels": {},
+			"annotations": {}
+		},
+		"links": {
+			"self": {
+			"href": "https://api.example.org/v3/service_instances/%[1]s"
+			},
+			"service_plan": {
+			"href": "https://api.example.org/v3/service_plans/%[4]s"
+			},
+			"space": {
+			"href": "https://api.example.org/v3/spaces/%[2]s"
+			},
+			"parameters": {
+			"href": "https://api.example.org/v3/service_instances/%[1]s/parameters"
+			},
+			"service_credential_bindings": {
+			"href": "https://api.example.org/v3/service_credential_bindings?service_instance_guids=%[1]s"
+			},
+			"service_route_bindings": {
+			"href": "https://api.example.org/v3/service_route_bindings?service_instance_guids=%[1]s"
+			}
+		},
+		"included": {
+			"spaces": [
+				{ "name": "%[5]s" }
+			],
+			"organizations": [
+				{ "name": "%[6]s" }
+			]
+		}
+		}
+	`,
+	instanceGuid,
+	spaceGuid,
+	instanceName,
+	servicePlanGuid,
+	spaceName,
+	orgName,
 	)
 }

--- a/testfixtures/api_space.go
+++ b/testfixtures/api_space.go
@@ -3,6 +3,7 @@ package testfixtures
 import "fmt"
 
 const V3SpaceGuid = "7ea72c2f-d0f1-4f4a-987e-7993807ab188"
+const V3SpaceName = "a-space"
 
 var V3SpacePath = fmt.Sprintf("/v3/spaces/%s", V3SpaceGuid)
 var V3Space = fmt.Sprintf(`
@@ -10,7 +11,7 @@ var V3Space = fmt.Sprintf(`
 	"guid": "%[1]s",
 	"created_at": "2017-02-01T01:33:58Z",
 	"updated_at": "2017-02-01T01:33:58Z",
-	"name": "my-space",
+	"name": "%[3]s",
 	"relationships": {
 	  "organization": {
 		"data": {
@@ -44,4 +45,5 @@ var V3Space = fmt.Sprintf(`
 `,
 	V3SpaceGuid,
 	V3OrgGuid,
+	V3SpaceName,
 )

--- a/testfixtures/configure.go
+++ b/testfixtures/configure.go
@@ -8,6 +8,7 @@ func ConfigureAPIServer(apiServer *APIServer) {
 
 	// Service instances
 	apiServer.PathReturns(V3ServiceInstancePath, []byte(V3ServiceInstance))
+	apiServer.PathReturns(V3ServiceInstanceWithOrgAndSpaceNamePath, []byte(V3ServiceInstanceWithOrgAndSpaceName))
 	apiServer.PathReturns(V3ServiceInstanceByNameListingPath, []byte(V3ServiceInstancesByNameListing))
 	apiServer.PathReturns(V3ServiceInstancesBySinglePlanListingPath, []byte(V3ServiceInstancesBySinglePlanListing))
 	apiServer.PathReturns(V3ServiceInstancesByMultiplePlanListingPath, []byte(V3ServiceInstancesByMultiplePlanListing))


### PR DESCRIPTION
Introduces a new command: `cf traverse service_instance org_space_name -d "/" SERVICE_INSTANCE_GUID`. This new command retrieves the service instance's organisation, space name, its own name, and separates them with the delimiter passed as `-d`

Resolves #15. 